### PR TITLE
Make Kotlin sample easier to compile

### DIFF
--- a/kotlin/KotlinEncryptionSample.kt
+++ b/kotlin/KotlinEncryptionSample.kt
@@ -1,17 +1,19 @@
-import android.util.Base64
+import java.util.Base64
 import java.security.KeyFactory
 import java.security.MessageDigest
 import java.security.PublicKey
 import java.security.spec.X509EncodedKeySpec
 import javax.crypto.Cipher
 
-const val ENCRYPTION_KEY_ID= "YOUR_ENCRIPTION_KEY_ID" // Provided by Rokt
-const val RSA_PUBLIC_KEY = "YOUR_PUBLIC_KEY"
+const val ENCRYPTION_KEY_ID= "YOUR_ENCRYPTION_KEY_ID" // Provided by Rokt
+
+// RSA_PUBLIC_KEY should be your RSA public key, which is a long string similar to this example:
+const val RSA_PUBLIC_KEY = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyAEV2RbqhRDM6eyb2qh8qLejdp7g1HwnxpbNS6CCrJKkyWsl3S2mQSvgaoxMELRWQNL77Pn2BWLC7zEn/qwi2Hcu5VS6+7z08RgDGSjmr9JOZahhWFjVyiZfePr+OBrhmz5RaSnH33d14Y4+rbK/Ypk7NVyNfiCZohAOZYdIALcImWUpivKUKgzy3YtLkhDl92wxOPIQcclCsx2keGhxiSkhkSZGMnvkm5Pmt6W6ISJEphnIx4e9irWNM+l57PXmytdQ91bSasYJfo7UckMvb4Jb9gh4+BnCGyN0zau+womqD4ZUj0QY30HdwanFftjVs/jI6hDHYlVZO+I50FspQIDAQAB"
 
 // Sample RSA encryption
 fun String.rsa(publicKey: String): String? {
     try {
-        val publicBytes: ByteArray = Base64.decode(publicKey, Base64.DEFAULT)
+        val publicBytes: ByteArray = Base64.getDecoder().decode(publicKey)
         val keySpec = X509EncodedKeySpec(publicBytes)
         val keyFactory: KeyFactory = KeyFactory.getInstance("RSA")
         val pubKey: PublicKey = keyFactory.generatePublic(keySpec)
@@ -19,14 +21,14 @@ fun String.rsa(publicKey: String): String? {
             init(Cipher.ENCRYPT_MODE, pubKey)
         }
         val encrypted = cipher.doFinal(this.toByteArray())
-        return Base64.encodeToString(encrypted, Base64.DEFAULT)
+        return Base64.getEncoder().encodeToString(encrypted)
     } catch (e: Exception) {
         e.printStackTrace()
     }
     return null
 }
 
-// Sample sha256 Encryption
+// Sample sha256 hash
 fun String.sha256(): String {
     return hashString(this, "SHA-256")
 }
@@ -50,7 +52,7 @@ fun executeEncrypted() {
     )
 
     // Encrypt PII using public KEY
-    attributes["emailEnc"] = "jenny@example.com".rsa(RSA_PUBLIC_KEY_PROD).orEmpty()
+    attributes["emailEnc"] = "jenny@example.com".rsa(RSA_PUBLIC_KEY).orEmpty()
     attributes["firstnameEnc"] = "jenny".rsa(RSA_PUBLIC_KEY).orEmpty()
 
     // Make sure you include your Encryption Key ID


### PR DESCRIPTION
Make the Kotlin sample easier to compile:

* Use `java.util.Base64`.
* Show what an RSA key should look like.
* Refer to SHA as a hash.
* Clarify reference to a const that doesn't exist.